### PR TITLE
[FIX] send total amount as euro in invoice

### DIFF
--- a/l10n_pt_account_invoicexpress/models/account_move.py
+++ b/l10n_pt_account_invoicexpress/models/account_move.py
@@ -108,7 +108,6 @@ class AccountMove(models.Model):
         }.get(doctype)
 
     def _prepare_invoicexpress_lines(self):
-        date_today = fields.Date.today()
         # FIXME: set user lang, based on country?
         lines = self.invoice_line_ids.filtered(
             lambda l: l.display_type not in ("line_section", "line_note")
@@ -129,7 +128,7 @@ class AccountMove(models.Model):
                     line.price_unit,
                     line.company_id.currency_id,
                     line.company_id,
-                    date_today,
+                    line.move_id.invoice_date or line.move_id.date or fields.Date.context_today(line),
                 )
             items.append(
                 {

--- a/l10n_pt_account_invoicexpress/models/account_move.py
+++ b/l10n_pt_account_invoicexpress/models/account_move.py
@@ -129,7 +129,7 @@ class AccountMove(models.Model):
                     line.price_unit,
                     line.company_id.currency_id,
                     line.company_id,
-                    date_today
+                    date_today,
                 )
             items.append(
                 {

--- a/l10n_pt_account_invoicexpress/models/account_move.py
+++ b/l10n_pt_account_invoicexpress/models/account_move.py
@@ -124,7 +124,7 @@ class AccountMove(models.Model):
                     "name": line.product_id.default_code
                     or line.product_id.display_name,
                     "description": line._get_invoicexpress_descr(),
-                    "unit_price": line.price_unit,
+                    "unit_price": abs(line.balance),
                     "quantity": line.quantity,
                     "discount": line.discount,
                     "tax": tax_detail,

--- a/l10n_pt_account_invoicexpress/models/account_move.py
+++ b/l10n_pt_account_invoicexpress/models/account_move.py
@@ -122,7 +122,7 @@ class AccountMove(models.Model):
             tax_detail = {"name": tax.name or "IVA0", "value": tax.amount or 0.0}
             # Because InvoiceXpress expects unit_price in EUR, check if we need to convert
             # line currency to company currency (company should use EUR as default currency)
-            if line.currency_id.id == line.company_id.currency_id.id:
+            if line.currency_id == line.company_id.currency_id:
                 price_unit = line.price_unit
             else:
                 price_unit = line.currency_id._convert(


### PR DESCRIPTION
Found out that when sending the invoice amount using another currency than Euro, the conversion would be wrong. This is due to invoicexpress expecting to receive the amount in Euro and proceeding to exchange to whatever currency we sent. Using the balance field, Odoo will automatically exchange the amount to the currency that is set in the users Company, which needs to be set to Euro.