### PR TITLE
16.0 fix down payment

### DIFF
--- a/l10n_pt_account_invoicexpress/models/account_move.py
+++ b/l10n_pt_account_invoicexpress/models/account_move.py
@@ -369,8 +369,14 @@ class AccountMove(models.Model):
             ],
         })
 
+        # Post and reconcile credit note
         if l10npt_vat_exempt_reason:
             credit_note.action_post()
+
+            outstanding_lines = credit_note.line_ids
+            outstanding_lines = outstanding_lines.filtered(lambda l: float_compare(l.balance, 0.0, 2) < 0)
+            for outstanding_line in outstanding_lines:
+                self.js_assign_outstanding_line(outstanding_line.id)
 
     def _track_subtype(self, init_values):
         res = super()._track_subtype(init_values)


### PR DESCRIPTION
The goal of this PR is to allow to deduct down payments on an invoice using InvoiceXpress.

**First problem:**
1. Create an invoice with a down payment;
2. Create a second invoice and deduct down payments.
Odoo will create a negative line with the down payments on the second invoice. We can't have negative lines in InvoiceXpress.

**Second problem:**
We can't register a payment on a credit note. When we finalize a credit note in InvoiceXpress (the equivalent of posting a credit note in Odoo) it automatically changes the state to paid.

**Solution to first problem:**
When we post an invoice, we will look for down payments with negative amounts. Before the post, we will delete those negative lines from the invoice and delete the down payment section. After the post we will create, post and reconcile a new credit note linked with the invoice, using the deleted lines.

**Solution to second problem:**
We will prevent in Odoo the registration of a payment in the credit note, forcing a reconciliation in the source invoice instead. We will also prevent the registration of a payment in the source invoice, if the source invoice has outstanding credits.