### PR TITLE
[16.0][FIX] l10n_pt_vat: Fiscal zone invisible if country is not Portugal

### DIFF
--- a/l10n_pt_vat/views/account_tax_view.xml
+++ b/l10n_pt_vat/views/account_tax_view.xml
@@ -5,7 +5,10 @@
         <field name="inherit_id" ref="account.view_tax_form" />
         <field name="arch" type="xml">
             <field name="tax_group_id" position="after">
-                <field name="l10n_pt_fiscal_zone" />
+                <field
+                    name="l10n_pt_fiscal_zone"
+                    attrs="{'invisible': [('country_code', '!=', 'PT')]}"
+                />
             </field>
         </field>
     </record>


### PR DESCRIPTION
@loida-vm @dreispt please review. Thanks!

Company is from Portugal
![image](https://github.com/user-attachments/assets/b6880ae9-4612-40b8-838d-660c190bff18)

Company is not from Portugal
![image](https://github.com/user-attachments/assets/c8852ffb-cf33-4c6b-8a87-e1fb337d48d5)


@moduon MT-9204