### PR TITLE
[14.0][IMP] l10n_pt_stock_vehicle_daily: Automatically populate the corresp…

### DIFF
--- a/l10n_pt_stock_vehicle_daily/models/stock_picking.py
+++ b/l10n_pt_stock_vehicle_daily/models/stock_picking.py
@@ -1,10 +1,21 @@
 # Copyright 2024 Open Source Integrators
+# Copyright 2025 NuoBiT Solutions - Deniz Gallo <dgallo@nuobit.com>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class StockPicking(models.Model):
     _inherit = "stock.picking"
 
-    l10n_pt_license_plate = fields.Char("License Plate")
+    l10n_pt_license_plate = fields.Char(
+        string="License Plate",
+        compute="_compute_l10n_pt_license_plate",
+        store=True,
+        readonly=False,
+    )
+
+    @api.depends("location_id")
+    def _compute_l10n_pt_license_plate(self):
+        for picking in self:
+            picking.l10n_pt_license_plate = picking.location_id.l10n_pt_license_plate

--- a/l10n_pt_stock_vehicle_daily/views/stock_picking_views.xml
+++ b/l10n_pt_stock_vehicle_daily/views/stock_picking_views.xml
@@ -1,16 +1,12 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo>
-
     <record id="view_picking_form_ext" model="ir.ui.view">
         <field name="model">stock.picking</field>
         <field name="inherit_id" ref="stock.view_picking_form" />
         <field name="arch" type="xml">
-
             <group name="other_infos" position="inside">
                 <field name="l10n_pt_license_plate" />
             </group>
-
         </field>
     </record>
-
 </odoo>


### PR DESCRIPTION
…onding license plate for the selected location

Automatically populate the corresponding license plate for the selected location,

![image](https://github.com/user-attachments/assets/fce8a227-9b7b-45e3-9fb6-92ee2d2005b2)


 just as it is currently done in the Wizard Stock Move Location.

![image](https://github.com/user-attachments/assets/fbb3c5c8-a987-42a6-9b4d-32b720ffbff3)

@dreispt @eantones @FrankC013 can you please review