### PR TITLE
[16.0][FIX] Tests don't load Coa

### DIFF
--- a/l10n_pt_account_invoicexpress/tests/test_invoicexpress.py
+++ b/l10n_pt_account_invoicexpress/tests/test_invoicexpress.py
@@ -19,6 +19,16 @@ class TestInvoiceXpress(common.TransactionCase):
     def setUp(self):
         super().setUp()
 
+        if not self.env.company.chart_template_id:
+            # Load a CoA if there's none in current company
+            coa = self.env.ref("l10n_generic_coa.configurable_chart_template", False)
+            if not coa:
+                # Load the first available CoA
+                coa = self.env["account.chart.template"].search(
+                    [("visible", "=", True)], limit=1
+                )
+            coa.try_loading(company=self.env.company, install_demo=False)
+
         self.company = self.env.company
         self.company.write(
             {

--- a/l10n_pt_stock_invoicexpress/tests/test_invoicexpress.py
+++ b/l10n_pt_stock_invoicexpress/tests/test_invoicexpress.py
@@ -23,6 +23,16 @@ def mock_response(json, status_code=200):
 class TestInvoiceXpressStock(TestInvoiceXpress):
     def setUp(self):
         super().setUp()
+        if not self.env.company.chart_template_id:
+            # Load a CoA if there's none in current company
+            coa = self.env.ref("l10n_generic_coa.configurable_chart_template", False)
+            if not coa:
+                # Load the first available CoA
+                coa = self.env["account.chart.template"].search(
+                    [("visible", "=", True)], limit=1
+                )
+            coa.try_loading(company=self.env.company, install_demo=False)
+
         self.StockPicking = self.env["stock.picking"]
 
     @patch.object(requests, "request")


### PR DESCRIPTION
After this commit https://github.com/odoo/odoo/commit/d0342c8 the Coa is not loaded in the test, so we need to load it manually.

@dreispt please review, thank you.