### PR TITLE
[17.0][FIX] l10n_pt_vat: Fiscal zone invisible if country is not Portugal

### DIFF
--- a/l10n_pt_vat/views/account_tax_view.xml
+++ b/l10n_pt_vat/views/account_tax_view.xml
@@ -5,7 +5,7 @@
         <field name="inherit_id" ref="account.view_tax_form" />
         <field name="arch" type="xml">
             <field name="tax_group_id" position="after">
-                <field name="l10n_pt_fiscal_zone" />
+                <field name="l10n_pt_fiscal_zone" invisible="country_code != 'PT'" />
             </field>
         </field>
     </record>


### PR DESCRIPTION
Fw-port of https://github.com/OCA/l10n-portugal/pull/126

@dreispt can you review when you can? Thank you!

@moduon MT-9204