### PR TITLE
[BKP] l10n_pt_[*]_invoicexpress: backports for 18.0

### DIFF
--- a/l10n_pt_account_invoicexpress/data/neutralize.sql
+++ b/l10n_pt_account_invoicexpress/data/neutralize.sql
@@ -1,0 +1,4 @@
+-- disable InvoiceXpress connection
+UPDATE res_company
+   SET invoicexpress_account_name = NULL
+ WHERE invoicexpress_account_name IS NOT NULL;

--- a/l10n_pt_stock_invoicexpress/models/stock_picking.py
+++ b/l10n_pt_stock_invoicexpress/models/stock_picking.py
@@ -283,7 +283,9 @@ class StockPicking(models.Model):
         """
         res = super().button_validate()
         if res is True:  # do not enter if the result is a dict, only if it is True
-            missing_country = self.filtered(lambda x: not x.partner_id.country_id)
+            missing_country = self.filtered(
+                lambda x: x.can_invoicexpress and not x.partner_id.country_id
+            )
             if missing_country:
                 raise exceptions.UserError(_("Please set the country of the partner."))
             to_invoicexpress = self.filtered(

--- a/l10n_pt_stock_invoicexpress/models/stock_picking_type.py
+++ b/l10n_pt_stock_invoicexpress/models/stock_picking_type.py
@@ -8,6 +8,7 @@ class StockPickingType(models.Model):
     _inherit = "stock.picking.type"
 
     def _default_invoicexpress_doc_type(self):
+        # used in res.config.settings
         return (
             "transport"
             if self.company_id.has_invoicexpress and self.code == "outgoing"
@@ -20,7 +21,6 @@ class StockPickingType(models.Model):
             ("shipping", "Guia de Remessa / Shipping"),
             ("none", "No InvoiceXpress document"),
         ],
-        default="transport",
         help="Select the type of legal delivery document"
         " to be created by InvoiceXpress. If unset",
     )


### PR DESCRIPTION
- [IMP] l10n_pt_account_invoicexpress: neutralize test DBs
- [FIX] l10n_pt_stock_invoicexpress: default wrong for non PT deliveries
- [FIX] l10n_pt_stock_invoicexpress: allow transfers withour a Partner set
