### PR TITLE
[FIX] l10n_pt_stock_invoicexpress: fix argument

### DIFF
--- a/l10n_pt_stock_invoicexpress/models/stock_picking.py
+++ b/l10n_pt_stock_invoicexpress/models/stock_picking.py
@@ -275,7 +275,7 @@ class StockPicking(models.Model):
                     email=payload["message"]["client"]["email"],
                     cc=payload["message"]["cc"] or _("None"),
                 )
-                delivery.message_post(Markup(body=msg))
+                delivery.message_post(body=Markup(msg))
 
     def button_validate(self):
         """


### PR DESCRIPTION

The following error is fixed with the Markup function argument

<img width="1051" height="224" alt="image" src="https://github.com/user-attachments/assets/b3e07c20-9482-4447-ba12-e14f1901b8af" />
