### PR TITLE
[FIX] single error on response

### DIFF
--- a/l10n_pt_account_invoicexpress/models/account_invoicexpress.py
+++ b/l10n_pt_account_invoicexpress/models/account_invoicexpress.py
@@ -57,10 +57,15 @@ class InvoiceXpress(models.AbstractModel):
         # TODO: implement request rate limit
         if response.status_code not in [200, 201]:
             if response.json():
-                msg = "\n".join(
-                    "- " + (x.get("error") or repr(x))
-                    for x in response.json().get("errors", [])
-                )
+                errors = response.json().get("errors", [])
+                if isinstance(errors, list) and len(errors) > 0:
+                    msg = "\n".join(
+                        "- " + (x.get("error") or repr(x))
+                        for x in response.json().get("errors", [])
+                    )
+                elif isinstance(errors, dict):
+                    msg = errors.get("error", False) or repr(errors)
+
             else:
                 msg = repr(response.json())
             raise exceptions.ValidationError(


### PR DESCRIPTION
When the response has a single "error" is raised the following error:

<img width="1059" height="331" alt="image" src="https://github.com/user-attachments/assets/4782299a-fd03-4864-96bb-a6d6cb3c920f" />
