### PR TITLE
[FIX] l10n_pt_vat: Display fields on invoice form view if user belong…

### DIFF
--- a/l10n_pt_account_invoicexpress/models/account_move.py
+++ b/l10n_pt_account_invoicexpress/models/account_move.py
@@ -13,7 +13,8 @@ class AccountMove(models.Model):
     def _compute_show_reset_to_draft_button(self):
         super()._compute_show_reset_to_draft_button()
         # InvoiceXpress generated invoices can't be set to Draft
-        self.filtered("invoicexpress_id").write({"show_reset_to_draft_button": False})
+        for move in self.filtered("invoicexpress_id"):
+            move.show_reset_to_draft_button = False
         return
 
     @api.depends("move_type", "journal_id.use_invoicexpress")

--- a/l10n_pt_vat/views/account_move_view.xml
+++ b/l10n_pt_vat/views/account_move_view.xml
@@ -11,11 +11,13 @@
                     <field
                         name="l10npt_vat_exempt_reason"
                         widget="selection"
+                        groups="account.group_account_user"
                         attrs="{'invisible': [('country_code', '!=', 'PT')]}"
                     />
                     <field name="move_type" invisible="1" />
                     <field
                         name="vat_adjustment_norm_id"
+                        groups="account.group_account_user"
                         attrs="{'invisible': ['|',('country_code', '!=', 'PT'),('move_type', 'not in',
                          ['out_refund', 'in_refund'])]}"
                         domain="[('move_type', '=', move_type)]"


### PR DESCRIPTION
Display fields on invoice form view if user belongs to group `account.group_account_user`

In order to read l10npt_vat_exempt_reason and vat_adjustment_norm_id fields, user must belong to account.group_account_user group