### PR TITLE
[FIX] l10n_pt_certification: avoid crash when res_ids is None

### DIFF
--- a/l10n_pt_certification/models/ir_actions_report.py
+++ b/l10n_pt_certification/models/ir_actions_report.py
@@ -10,7 +10,7 @@ class IrActionsReport(models.Model):
     _inherit = 'ir.actions.report'
 
     def _pre_render_qweb_pdf(self, report_ref, res_ids=None, data=None):
-        if len(res_ids) > 1:
+      if res_ids and len(res_ids) > 1:
             # Check that, if multiple documents being printed, only PT companies are selected,
             # as mixing companies from different countries may lead to missing template elements.
             pt_companies = self.env.companies.filtered(lambda c: c.country_code == 'PT')

--- a/l10n_pt_certification/models/ir_actions_report.py
+++ b/l10n_pt_certification/models/ir_actions_report.py
@@ -10,7 +10,7 @@ class IrActionsReport(models.Model):
     _inherit = 'ir.actions.report'
 
     def _pre_render_qweb_pdf(self, report_ref, res_ids=None, data=None):
-      if res_ids and len(res_ids) > 1:
+        if res_ids and len(res_ids) > 1:
             # Check that, if multiple documents being printed, only PT companies are selected,
             # as mixing companies from different countries may lead to missing template elements.
             pt_companies = self.env.companies.filtered(lambda c: c.country_code == 'PT')


### PR DESCRIPTION
## Description
Fix crash when printing QWeb PDF reports without docids.

`res_ids` may be `None` when the report is triggered from a menu or button
without explicit document IDs, causing a `TypeError` when calling `len()`.

This PR adds a defensive check before evaluating the number of records.

## Steps to reproduce
1. Trigger a certified report without docids
2. Odoo raises `TypeError: object of type 'NoneType' has no len()`

## Fix
Ensure `res_ids` is defined before calling `len(res_ids)`.

## Impact
- Prevents RPC_ERROR on report download
- Keeps existing multi-document validation logic intact

## Version
- Odoo 18.0
