### PR TITLE
[16.0][IMP] l10n_pt_account_invoicexpress: inheritable methods

### DIFF
--- a/l10n_pt_account_invoicexpress/models/account_move.py
+++ b/l10n_pt_account_invoicexpress/models/account_move.py
@@ -121,11 +121,10 @@ class AccountMove(models.Model):
             tax_detail = {"name": tax.name or "IVA0", "value": tax.amount or 0.0}
             # Because InvoiceXpress expects unit_price in EUR, check if we need to convert
             # line currency to company currency (company should use EUR as default currency)
-            if line.currency_id == line.company_id.currency_id:
-                price_unit = line.price_unit
-            else:
+            price_unit = line._get_invoicexpress_price_unit()
+            if line.currency_id != line.company_id.currency_id:
                 price_unit = line.currency_id._convert(
-                    line.price_unit,
+                    price_unit,
                     line.company_id.currency_id,
                     line.company_id,
                     line.move_id.invoice_date
@@ -229,20 +228,23 @@ class AccountMove(models.Model):
                 raise_errors=True,
             ).json()
             values1 = response1.get(doctype)
-            seqnum = values1 and values1.get("inverted_sequence_number")
-            if not seqnum:
-                raise exceptions.UserError(
-                    _(
-                        "Something went wrong: the InvoiceXpress response"
-                        " is missing a sequence number."
-                    )
-                )
-            prefix = self._get_invoicexpress_prefix(doctype)
-            invx_number = "%s %s" % (prefix, seqnum) if prefix else seqnum
-            if invoice.payment_reference == invoice.name:
-                invoice.payment_reference = invx_number
-            invoice.name = invx_number
+            invoice._update_values_from_invoicexpress_finalized_response(values1)
             invoice._update_invoicexpress_status()
+
+    def _update_values_from_invoicexpress_finalized_response(self, values):
+        seqnum = values and values.get("inverted_sequence_number")
+        if not seqnum:
+            raise exceptions.UserError(
+                _(
+                    "Something went wrong: the InvoiceXpress response"
+                    " is missing a sequence number."
+                )
+            )
+        prefix = self._get_invoicexpress_prefix(self.invoicexpress_doc_type)
+        invx_number = "%s %s" % (prefix, seqnum) if prefix else seqnum
+        if self.payment_reference == self.name:
+            self.payment_reference = invx_number
+        self.name = invx_number
 
     def _prepare_invoicexpress_email_vals(self, ignore_no_config=False):
         self.ensure_one()
@@ -354,3 +356,6 @@ class AccountMoveLine(models.Model):
         if ref and self.name.startswith(prefix):
             res = self.name[len(prefix) :]
         return res
+
+    def _get_invoicexpress_price_unit(self):
+        return self.price_unit

--- a/l10n_pt_account_invoicexpress/tests/test_invoicexpress.py
+++ b/l10n_pt_account_invoicexpress/tests/test_invoicexpress.py
@@ -3,6 +3,7 @@ from unittest.mock import Mock, patch
 import requests
 
 from odoo import fields
+from odoo.exceptions import UserError
 from odoo.tests import Form, common
 
 
@@ -136,3 +137,22 @@ class TestInvoiceXpress(common.TransactionCase):
         self.assertEqual(invoice.invoicexpress_doc_type, "invoice_receipt")
         self.assertEqual(invoice.invoicexpress_id, "12345678")
         self.assertEqual(invoice.name, "FR MYSEQ/123")
+
+    @patch.object(requests, "request")
+    def test_102_create_invoicexpress_invoice_missing_sequence(self, mock_request):
+        mock_request.return_value = mock_response(
+            {
+                "invoice_receipt": {
+                    "id": 12345678,
+                }
+            }
+        )
+        self.sale_journals.write({"invoicexpress_doc_type": "invoice_receipt"})
+        move_form = Form(self.AccountMove.with_context(default_move_type="out_invoice"))
+        move_form.invoice_date = fields.Date.today()
+        move_form.partner_id = self.partnerA
+        with move_form.invoice_line_ids.new() as line_form:
+            line_form.product_id = self.productA
+        invoice = move_form.save()
+        with self.assertRaises(UserError):
+            invoice.action_post()


### PR DESCRIPTION
Make some functionality inheritable.
- When invoice is finalized, sometimes it's necessary to store some additional information, such the ATCUD or the hash
- The unit price is extracted from the invoice lines into a method in order to provide better coverage for special cases that customers may have. Sometimes the unit price that needs to be sent to InvoiceXpress is not the one stored on the invoice line, but instead requires some calculations. This can happen, for example, in cases where there are additional line-level discounts, or when the price includes taxes, since InvoiceXpress only supports a price field and a discount field, and its tax handling does not allow for taxes to be included in the price. Therefore, it would not be possible to send an invoice from Odoo whose lines have taxes included, or that have other taxes per line, because the total amount of the invoice in InvoiceXpress would be incorrect.