### PR TITLE
[19.0][FIX] l10n_pt_account_invoicexpress: company-dependent invoicexpress_code and migration

### DIFF
--- a/l10n_pt_account_invoicexpress/__manifest__.py
+++ b/l10n_pt_account_invoicexpress/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Portugal InvoiceXpress Integration",
     "summary": "Portuguese certified invoices using InvoiceXpress",
-    "version": "19.0.1.0.0",
+    "version": "19.0.2.0.1",
     "author": "Open Source Integrators, Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "website": "https://github.com/OCA/l10n-portugal",
@@ -19,6 +19,7 @@
         "views/account_move_view.xml",
         "views/res_company_view.xml",
         "views/res_country_view.xml",
+        "views/res_partner_view.xml",
         "data/mail_template.xml",
         "data/res.country.csv",
     ],

--- a/l10n_pt_account_invoicexpress/migrations/19.0.2.0.1/post-migrate.py
+++ b/l10n_pt_account_invoicexpress/migrations/19.0.2.0.1/post-migrate.py
@@ -1,0 +1,90 @@
+# Copyright (C) 2021 Open Source Integrators
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+import logging
+
+_logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    cr.execute("SELECT id FROM res_company WHERE active = true")
+    company_ids = [row[0] for row in cr.fetchall()]
+    if not company_ids:
+        _logger.info("No active companies found; nothing to migrate")
+        return
+
+    _logger.info(
+        "Populating empty invoicexpress_code entries from invoicexpress_id "
+        "for active companies %s",
+        company_ids,
+    )
+
+    # Partners restricted to a single company: set the code for that company only
+    # when it does not already have a value there.
+    cr.execute(
+        """
+        UPDATE res_partner
+        SET invoicexpress_code =
+            COALESCE(invoicexpress_code, '{}'::jsonb)
+            || jsonb_build_object(company_id::text, invoicexpress_id)
+        WHERE invoicexpress_id IS NOT NULL
+          AND invoicexpress_id != ''
+          AND company_id IS NOT NULL
+          AND (
+              invoicexpress_code IS NULL
+              OR NOT (invoicexpress_code ? company_id::text)
+          )
+        """
+    )
+    migrated = cr.rowcount
+
+    if len(company_ids) == 1:
+        company_id = company_ids[0]
+        cr.execute(
+            """
+            UPDATE res_partner
+            SET invoicexpress_code =
+                COALESCE(invoicexpress_code, '{}'::jsonb)
+                || jsonb_build_object(%s::text, invoicexpress_id)
+            WHERE invoicexpress_id IS NOT NULL
+              AND invoicexpress_id != ''
+              AND company_id IS NULL
+              AND (
+                  invoicexpress_code IS NULL
+                  OR NOT (invoicexpress_code ? %s)
+              )
+            """,
+            (company_id, str(company_id)),
+        )
+    else:
+        # Shared partners: set the code for every active company that does not
+        # already have one, preserving any existing per-company values.
+        cr.execute(
+            """
+            UPDATE res_partner rp
+            SET invoicexpress_code =
+                COALESCE(rp.invoicexpress_code, '{}'::jsonb) || sub.code_obj
+            FROM (
+                SELECT rp2.id,
+                       jsonb_object_agg(c.id::text, rp2.invoicexpress_id) AS code_obj
+                FROM res_partner rp2
+                CROSS JOIN res_company c
+                WHERE rp2.invoicexpress_id IS NOT NULL
+                  AND rp2.invoicexpress_id != ''
+                  AND rp2.company_id IS NULL
+                  AND c.active = true
+                  AND (
+                      rp2.invoicexpress_code IS NULL
+                      OR NOT (rp2.invoicexpress_code ? c.id::text)
+                  )
+                GROUP BY rp2.id
+            ) sub
+            WHERE rp.id = sub.id
+            """
+        )
+
+    migrated += cr.rowcount
+    _logger.info(
+        "Migrated %d partner(s) from invoicexpress_id to invoicexpress_code",
+        migrated,
+    )

--- a/l10n_pt_account_invoicexpress/models/account_invoicexpress.py
+++ b/l10n_pt_account_invoicexpress/models/account_invoicexpress.py
@@ -49,25 +49,38 @@ class InvoiceXpress(models.AbstractModel):
     def _check_http_status(self, response):
         """
         You can perform up to 100 requests per minute for each Account. If you exceed
-        this limit, you’ll get a 429 Too Many Requests response for subsequent requests.
+        this limit, you'll get a 429 Too Many Requests response for subsequent requests.
 
         We recommend you handle 429 responses so your integration retries requests
         automatically.
         """
         # TODO: implement request rate limit
         if response.status_code not in [200, 201]:
-            if response.json():
-                errors = response.json().get("errors", [])
-                if isinstance(errors, list) and len(errors) > 0:
-                    msg = "\n".join(
-                        "- " + (x.get("error") or repr(x))
-                        for x in response.json().get("errors", [])
-                    )
-                elif isinstance(errors, dict):
-                    msg = errors.get("error", False) or repr(errors)
+            errors = []
+            json_data = None
+            try:
+                if response.content:
+                    json_data = response.json()
+                    errors = json_data.get("errors", [])
+            except (ValueError, requests.exceptions.JSONDecodeError):
+                # Response doesn't contain JSON, use text content or empty errors
+                if response.text:
+                    errors = [response.text]
 
+            if isinstance(errors, list) and len(errors) > 0:
+                msg = "\n".join(
+                    "- " + (x.get("error") if isinstance(x, dict) else str(x))
+                    for x in errors
+                )
+            elif isinstance(errors, dict):
+                msg = errors.get("error", False) or repr(errors)
+            elif json_data:
+                # If we have JSON but no errors field, show the whole response
+                msg = repr(json_data)
             else:
-                msg = repr(response.json())
+                # Handle empty responses or provide a more descriptive message
+                msg = response.text or ""
+
             raise exceptions.ValidationError(
                 self.env._(
                     "Error running API request (%(status_code)s %(reason)s):\n%(json)s",

--- a/l10n_pt_account_invoicexpress/models/account_move.py
+++ b/l10n_pt_account_invoicexpress/models/account_move.py
@@ -160,7 +160,7 @@ class AccountMove(models.Model):
                 self.env._("Kindly add the invoice date and invoice due date.")
             )
         customer = self._get_invoicexpress_partner()
-        customer_vals = customer.set_invoicexpress_contact()
+        customer_vals = customer.set_invoicexpress_contact(company=self.company_id)
         items = self._prepare_invoicexpress_lines()
         proprietary_uid = "ODOO" + str(uuid.uuid4()).replace("-", "")
         invoice_data = {

--- a/l10n_pt_account_invoicexpress/models/res_partner.py
+++ b/l10n_pt_account_invoicexpress/models/res_partner.py
@@ -7,13 +7,24 @@ from odoo import fields, models
 class ResPartner(models.Model):
     _inherit = "res.partner"
 
-    invoicexpress_id = fields.Char("InvoiceXpress ID", copy=False, readonly=True)
+    invoicexpress_code = fields.Char(
+        "InvoiceXpress Code",
+        copy=False,
+        company_dependent=True,
+        help="Company-specific identifier used for this partner in InvoiceXpress.",
+    )
+    invoicexpress_id = fields.Char(
+        "InvoiceXpress ID",
+        copy=False,
+        readonly=True,
+        help="Deprecated: will be removed in future versions",
+    )
 
     def _prepare_invoicexpress_vals(self):
         self.ensure_one()
         vals = {
             "name": self.name,
-            "code": f"ODOO-{self.ref or self.id}",
+            "code": self.invoicexpress_code,
             "email": self.email,
             "address": ", ".join(filter(None, [self.street, self.street2])),
             "city": self.city,
@@ -23,7 +34,7 @@ class ResPartner(models.Model):
             "website": self.website,
             "phone": self.phone,
         }
-        # InvoiceXpress document language (pt, es or rn)
+        # InvoiceXpress document language (pt, es or en)
         # Outside PT and ES use english
         # Could be a requirement for some border authorities
         country_code = self.country_id.code
@@ -35,7 +46,7 @@ class ResPartner(models.Model):
             vals["language"] = "en"
         return {k: v for k, v in vals.items() if v}
 
-    def set_invoicexpress_contact(self):
+    def set_invoicexpress_contact(self, company=False):
         self.ensure_one()
         if self.vat and self.country_id:
             # Double check VAT is right
@@ -44,38 +55,48 @@ class ResPartner(models.Model):
                 vat_prefix or self.country_id.code.lower(), vat_number
             )
         InvoiceXpress = self.env["account.invoicexpress"]
-        company = self.company_id or self.env.company
+        company = company or self.company_id or self.env.company
+        partner = self.with_company(company)
         doctype = "client"
-        vals = self._prepare_invoicexpress_vals()
-        invx_id_to_update = self.invoicexpress_id
-        if not invx_id_to_update:
-            # Create: POST /clients.json
+
+        if not partner.invoicexpress_code:
+            partner.invoicexpress_code = f"ODOO-{partner.ref or partner.id}"
+        vals = partner._prepare_invoicexpress_vals()
+
+        # Find existing client by code
+        response = InvoiceXpress.call(
+            company,
+            f"{doctype}s/find-by-code.json",
+            "GET",
+            params={"client_code": vals["code"]},
+            raise_errors=False,
+        )
+        # Create if missing: POST /clients.json
+        if response.status_code == 404:
             response = InvoiceXpress.call(
                 company,
                 f"{doctype}s.json",
                 "POST",
                 payload={"client": vals},
-                raise_errors=False,
             )
-            if response.status_code == 422:  # Oh, it already exists!
-                response = InvoiceXpress.call(
-                    company,
-                    f"{doctype}s/find-by-code.json",
-                    "GET",
-                    params={"client_code": vals["code"]},
-                )
-                values = response.json().get(doctype)
-                invx_id_to_update = values.get("id")  # Update is needed!
-            values = response.json().get(doctype, {})
-            self.invoicexpress_id = values.get("id")
+        else:
+            # Update existing client
+            # Check if VAT is the same, if not create a new contact
+            values = response.json().get(doctype)
+            if values and values.get("fiscal_id") != partner.vat:
+                code = partner.invoicexpress_code
+                new_code = f"ODOO-{partner.ref or partner.id}-{partner.vat or ''}"
+                if code != new_code:
+                    partner.invoicexpress_code = new_code
+                    return partner.set_invoicexpress_contact(company=company)
 
-        if invx_id_to_update:
             # Update: PUT /clients/$(client-id).json
+            client_id = values.get("id")
             response = InvoiceXpress.call(
                 company,
-                f"{doctype}s/{self.invoicexpress_id}.json",
+                f"{doctype}s/{client_id}.json",
                 "PUT",
                 payload={"client": vals},
-                raise_errors=True,
             )
+
         return {"name": vals["name"], "code": vals["code"]}

--- a/l10n_pt_account_invoicexpress/static/description/index.html
+++ b/l10n_pt_account_invoicexpress/static/description/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <meta name="generator" content="Docutils: https://docutils.sourceforge.io/" />
-<title>README.rst</title>
+<title>Portugal InvoiceXpress Integration</title>
 <style type="text/css">
 
 /*

--- a/l10n_pt_account_invoicexpress/tests/__init__.py
+++ b/l10n_pt_account_invoicexpress/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_invoicexpress
+from . import test_res_partner

--- a/l10n_pt_account_invoicexpress/tests/invoicexpress_mock.py
+++ b/l10n_pt_account_invoicexpress/tests/invoicexpress_mock.py
@@ -1,0 +1,90 @@
+from unittest.mock import Mock
+
+
+def mock_response(json, status_code=200):
+    """Create a mock HTTP response with the given JSON data and status code."""
+    response = Mock()
+    response.json.return_value = json
+    response.text = str(json)
+    response.status_code = status_code
+    return response
+
+
+def mock_request_side_effect(method, url, **kwargs):
+    """
+    Mock side effect for InvoiceXpress API requests.
+    Returns appropriate mock responses for different endpoints.
+    """
+    if "clients/find-by-code" in url:
+        return mock_response(
+            {"client": {"id": 999, "fiscal_id": "500000000", "name": "Customer A"}},
+            status_code=200,
+        )
+    elif "clients.json" in url and method == "POST":
+        return mock_response(
+            {"client": {"id": 999, "fiscal_id": "500000000", "name": "Customer A"}},
+            status_code=200,
+        )
+    elif "invoice_receipts.json" in url and method == "POST":
+        return mock_response(
+            {
+                "invoice_receipt": {
+                    "id": 12345678,
+                    "inverted_sequence_number": "MYSEQ/123",
+                }
+            },
+            status_code=200,
+        )
+    elif "transports.json" in url and method == "POST":
+        return mock_response(
+            {"transport": {"id": 12345678, "inverted_sequence_number": "MYSEQ/123"}},
+            status_code=200,
+        )
+    elif "shippings.json" in url and method == "POST":
+        return mock_response(
+            {"shipping": {"id": 12345678, "inverted_sequence_number": "MYSEQ/123"}},
+            status_code=200,
+        )
+    elif "devolutions.json" in url and method == "POST":
+        return mock_response(
+            {"devolution": {"id": 12345678, "inverted_sequence_number": "MYSEQ/123"}},
+            status_code=200,
+        )
+    elif "change-state.json" in url and method == "PUT":
+        # Detect document type from URL and return appropriate response
+        if "transports" in url:
+            return mock_response(
+                {
+                    "transport": {
+                        "id": 12345678,
+                        "inverted_sequence_number": "MYSEQ/123",
+                    }
+                },
+                status_code=200,
+            )
+        elif "shippings" in url:
+            return mock_response(
+                {"shipping": {"id": 12345678, "inverted_sequence_number": "MYSEQ/123"}},
+                status_code=200,
+            )
+        elif "devolutions" in url:
+            return mock_response(
+                {
+                    "devolution": {
+                        "id": 12345678,
+                        "inverted_sequence_number": "MYSEQ/123",
+                    }
+                },
+                status_code=200,
+            )
+        else:
+            return mock_response(
+                {
+                    "invoice_receipt": {
+                        "id": 12345678,
+                        "inverted_sequence_number": "MYSEQ/123",
+                    }
+                },
+                status_code=200,
+            )
+    return mock_response({}, status_code=200)

--- a/l10n_pt_account_invoicexpress/tests/test_invoicexpress.py
+++ b/l10n_pt_account_invoicexpress/tests/test_invoicexpress.py
@@ -1,17 +1,11 @@
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 import requests
 
 from odoo import fields
 from odoo.tests import Form, common
 
-
-def mock_response(json, status_code=200):
-    mock_response = Mock()
-    mock_response.json.return_value = json
-    mock_response.text = str(json)
-    mock_response.status_code = status_code
-    return mock_response
+from .invoicexpress_mock import mock_request_side_effect, mock_response
 
 
 @common.tagged("-at_install", "post_install")
@@ -100,16 +94,9 @@ class TestInvoiceXpress(common.TransactionCase):
         taxA.action_invoicexpress_tax_create()
         self.assertEqual(taxA.invoicexpress_id, "12345")
 
-    @patch.object(requests, "request")
+    @patch("requests.request")
     def test_101_create_invoicexpress_invoice(self, mock_request):
-        mock_request.return_value = mock_response(
-            {
-                "invoice_receipt": {
-                    "id": 12345678,
-                    "inverted_sequence_number": "MYSEQ/123",
-                }
-            }
-        )
+        mock_request.side_effect = mock_request_side_effect
         # Ensure Journal is configured
         self.sale_journals.write({"invoicexpress_doc_type": "invoice_receipt"})
         # Create the Invoice

--- a/l10n_pt_account_invoicexpress/tests/test_res_partner.py
+++ b/l10n_pt_account_invoicexpress/tests/test_res_partner.py
@@ -1,0 +1,49 @@
+# Copyright (C) 2021 Open Source Integrators
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from unittest.mock import patch
+
+from odoo.tests import common
+
+from .invoicexpress_mock import mock_response
+
+
+def _mock_set_invoicexpress_contact_request(method, url, **kwargs):
+    if method == "GET" and "find-by-code" in url:
+        return mock_response({}, status_code=404)
+    elif method == "POST" and "clients.json" in url:
+        return mock_response({"client": {"id": 999, "name": "Test Partner"}})
+    return mock_response({})
+
+
+@common.tagged("post_install", "-at_install")
+class TestResPartnerInvoiceXpress(common.TransactionCase):
+    def test_set_invoicexpress_contact_is_company_dependent(self):
+        """set_invoicexpress_contact writes the code only for the requested company."""
+        main_company = self.env.company
+        other_company = self.env["res.company"].create(
+            {
+                "name": "Other Company",
+                "invoicexpress_account_name": "ACCOUNT",
+                "invoicexpress_api_key": "APIKEY",
+                "country_id": self.env.ref("base.pt").id,
+            }
+        )
+        partner = self.env["res.partner"].create(
+            {
+                "name": "Test Partner",
+                "country_id": self.env.ref("base.pt").id,
+            }
+        )
+
+        with patch(
+            "requests.request",
+            side_effect=_mock_set_invoicexpress_contact_request,
+        ):
+            partner.set_invoicexpress_contact(company=other_company)
+
+        self.assertEqual(
+            partner.with_company(other_company).invoicexpress_code,
+            f"ODOO-{partner.id}",
+        )
+        self.assertFalse(partner.with_company(main_company).invoicexpress_code)

--- a/l10n_pt_account_invoicexpress/views/res_partner_view.xml
+++ b/l10n_pt_account_invoicexpress/views/res_partner_view.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="view_partner_form_invoicexpress" model="ir.ui.view">
+        <field name="name">res.partner.form.invoicexpress</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="account.view_partner_property_form" />
+        <field name="arch" type="xml">
+            <!-- Add InvoiceXpress fields to the Accounting tab -->
+            <xpath expr="//group[@id='invoice_send_settings']" position="inside">
+                <field name="invoicexpress_code" />
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/l10n_pt_stock_invoicexpress/models/stock_picking.py
+++ b/l10n_pt_stock_invoicexpress/models/stock_picking.py
@@ -147,7 +147,7 @@ class StockPicking(models.Model):
                 self.env._("Scheduled Date should be bigger than current datetime!")
             )
         customer = self.partner_id.commercial_partner_id
-        customer_vals = customer.set_invoicexpress_contact()
+        customer_vals = customer.set_invoicexpress_contact(company=self.company_id)
         if self.location_id.usage == "internal":  # Outgoing
             address_from = self.picking_type_id.warehouse_id.partner_id
             address_to = self.partner_id

--- a/l10n_pt_stock_invoicexpress/tests/test_invoicexpress.py
+++ b/l10n_pt_stock_invoicexpress/tests/test_invoicexpress.py
@@ -1,22 +1,15 @@
 from datetime import timedelta
-from unittest.mock import Mock, patch
-
-import requests
+from unittest.mock import patch
 
 from odoo import fields
 from odoo.tests import Form, common
 
+from odoo.addons.l10n_pt_account_invoicexpress.tests.invoicexpress_mock import (
+    mock_request_side_effect,
+)
 from odoo.addons.l10n_pt_account_invoicexpress.tests.test_invoicexpress import (
     TestInvoiceXpress,
 )
-
-
-def mock_response(json, status_code=200):
-    mock_response = Mock()
-    mock_response.json.return_value = json
-    mock_response.text = str(json)
-    mock_response.status_code = status_code
-    return mock_response
 
 
 @common.tagged("-at_install", "post_install")
@@ -24,18 +17,30 @@ class TestInvoiceXpressStock(TestInvoiceXpress):
     def setUp(self):
         super().setUp()
         self.StockPicking = self.env["stock.picking"]
-
-    @patch.object(requests, "request")
-    def test_102_create_invoicexpress_picking(self, mock_request):
-        mock_request.return_value = mock_response(
-            {"transport": {"id": 12345678, "inverted_sequence_number": "MYSEQ/123"}}
-        )
         stock_location = self.env.ref("stock.stock_location_stock")
         self.warehouse = self.env["stock.warehouse"].search(
-            [("lot_stock_id", "=", stock_location.id)], limit=1
+            [
+                ("lot_stock_id", "=", stock_location.id),
+                ("company_id", "=", self.company.id),
+            ],
+            limit=1,
         )
+        if not self.warehouse:
+            # Create a warehouse for the test company if none exists
+            self.warehouse = self.env["stock.warehouse"].create(
+                {
+                    "name": "Test Warehouse",
+                    "company_id": self.company.id,
+                    "lot_stock_id": stock_location.id,
+                }
+            )
         # Setup defaults for Operation Types
         self.warehouse.company_id._update_default_doctype()
+        self.warehouse.out_type_id.invoicexpress_doc_type = "transport"
+
+    @patch("requests.request")
+    def test_102_create_invoicexpress_picking(self, mock_request):
+        mock_request.side_effect = mock_request_side_effect
         # Create a new picking with one product
         picking_form = Form(self.StockPicking)
         picking_form.partner_id = self.partnerA


### PR DESCRIPTION
## Summary

Forward-port of #176 to 19.0, supersedes #166.

- Replaces the global `invoicexpress_id` with the company-dependent `invoicexpress_code` on `res.partner`.
- Adds `migrations/19.0.2.0.1/post-migrate.py` to copy legacy `invoicexpress_id` values into the new JSONB field, creating one key per active company and preserving existing per-company values.
- Updates `set_invoicexpress_contact` to use `with_company(company)` when reading/writing the code, and updates `account_move` and `stock_picking` call sites to pass `company=self.company_id`.
- Adds `tests/test_res_partner.py` verifying per-company code assignment and refactors account/stock tests to use a shared `invoicexpress_mock`.
- Keeps the deprecated `invoicexpress_id` field for backward compatibility.

Assisted-by: Devin